### PR TITLE
Add Terraform plan and prompt for confirmation

### DIFF
--- a/roles/infra/defaults/main.yml
+++ b/roles/infra/defaults/main.yml
@@ -13,3 +13,7 @@ terraform_variables: {}
 
 # The gateway user defaults to the regular SSH user
 cluster_gateway_user: "{{ cluster_ssh_user }}"
+
+# Automatically approve Terraform apply and don't prompt
+# for confirmation
+terraform_autoapprove: true

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -8,8 +8,36 @@
       }
     dest: "{{ terraform_project_path }}/backend.tf"
 
+- name: Create Terraform plan
+  community.general.terraform:
+    binary_path: "{{ terraform_binary_path or omit }}"
+    project_path: "{{ terraform_project_path }}"
+    state: planned
+    backend_config: "{{ terraform_backend_config }}"
+    plan_file: terraform.plan
+    force_init: yes
+    init_reconfigure: yes
+    variables: "{{ terraform_variables }}"
+  register: _tf_plan
+
+- name: Show Terraform plan
+  debug:
+    msg: "{{ _tf_plan.stdout }}"
+
+- name: Prompt to approve Terraform plan execution
+  pause:
+    prompt: "Do you want to execute this plan? (Only 'yes' executes)"
+  register: _tf_approve_plan
+  when:
+    - "'No changes. Your infrastructure matches the configuration.' not in _tf_plan.stdout"
+    - 'not terraform_autoapprove | bool'
+
+- name: End host if Terraform plan is not approved
+  ansible.builtin.meta: end_host
+  when: "not (( terraform_autoapprove | bool ) or ( _tf_approve_plan.user_input | bool ))"
+
 - name: Provision infrastructure using Terraform
-  terraform:
+  community.general.terraform:
     binary_path: "{{ terraform_binary_path or omit }}"
     project_path: "{{ terraform_project_path }}"
     state: "{{ terraform_state }}"
@@ -17,7 +45,13 @@
     force_init: yes
     init_reconfigure: yes
     variables: "{{ terraform_variables }}"
+    plan_file: terraform.plan
   register: terraform_provision
+
+- name: Show Terraform provision output
+  debug:
+    msg: "{{ terraform_provision.stdout }}"
+  when: "'stdout' in terraform_provision"
 
 - name: Populate in-memory inventory
   block:


### PR DESCRIPTION
Run Terraform plan, and output the plan to stdout, then use the plan in in the subsequent apply step. Prompt the user in between to accept the plan, and provide a variable terraform_autoapprove to always apply the plan. terraform_autoapprove is true by default to maintain existing behaviour.