### PR TITLE
Bump OpenTofu to version 1.8.3

### DIFF
--- a/roles/infra/defaults/main.yml
+++ b/roles/infra/defaults/main.yml
@@ -19,3 +19,7 @@ cluster_gateway_user: "{{ cluster_ssh_user }}"
 
 # Adopt infrastructure into the in-memory inventory
 terraform_adopt_inventory: true
+
+# Disable checks for force_path_style s3 option
+terraform_disable_s3_force_path_style_checks: false
+

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -8,9 +8,42 @@
       }
     dest: "{{ terraform_project_path }}/backend.tf"
 
+- name: Set intermediate fact from terraform_backend_config
+  # We need this to be sure that we can beat the precedence of
+  # of terraform_backend_config in the next block, even if it
+  # is supplied as a role param
+  set_fact:
+    _terraform_backend_config: "{{ terraform_backend_config }}"
+
+- block:
+  - name: Warn if force_path_style is used in terraform_backend_config
+    # A simple debug.msg isn't obvious in stdout, so fail and ignore the
+    # failure.
+    fail:
+      msg: >-
+        The terraform_backend_config.force_path_style configuration
+        option is deprecated and terraform_backend_config.use_path_style
+        should be used instead!
+    ignore_errors: true
+
+  - name: Rename force_path_style to use_path_style
+    set_fact:
+      _terraform_backend_config: >-
+        {{
+          terraform_backend_config |
+          dict2items |
+          rejectattr('key', 'eq', 'force_path_style') |
+          items2dict |
+          combine({'use_path_style': terraform_backend_config.force_path_style})
+        }}
+  when:
+    - terraform_backend_type is defined and terraform_backend_type == 's3'
+    - terraform_backend_config.force_path_style is defined
+    - not terraform_disable_s3_force_path_style_checks
+
 - name: Write backend configuration options
   copy:
-    content: "{{ terraform_backend_config | to_json }}"
+    content: "{{ _terraform_backend_config | to_json }}"
     dest: "{{ terraform_project_path }}/backend_config.json"
 
 - name: Provision infrastructure using Terraform

--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -1,7 +1,7 @@
 # Acceptable OpenTofu versions. If a binary fulfilling these criteria is not found,
 # terraform_version_max will be downloaded.
-terraform_version_min: 1.6.0
-terraform_version_max: 1.6.1
+terraform_version_min: 1.8.3
+terraform_version_max: 1.8.3
 
 # The OS variant and architecture to use
 terraform_os: "{{ ansible_system | lower }}"


### PR DESCRIPTION
OpenTofu version 1.8.3 (and probably earlier) prints a warning about to stdout about the [deprecation of the `force_path_style` s3 backend config option.](https://github.com/opentofu/opentofu/pull/787). This breaks Ansible's parsing of the JSON stdout from OpenTofu:

```
TASK [azimuth_cloud.terraform.infra : Provision infrastructure using Terraform] ***********************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: json.decoder.JSONDecodeError: Extra data: line 61 column 1 (char 3006)
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/matta/.ansible/tmp/ansible-tmp-1729106813.3794572-1995946-18657772410840/AnsiballZ_terraform.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/matta/.ansible/tmp/ansible-tmp-1729106813.3794572-1995946-18657772410840/AnsiballZ_terraform.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/matta/.ansible/tmp/ansible-tmp-1729106813.3794572-1995946-18657772410840/AnsiballZ_terraform.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.terraform', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.terraform', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_terraform_payload_wd5iv42a/ansible_terraform_payload.zip/ansible_collections/community/general/plugins/modules/terraform.py\", line 734, in <module>\n  File \"/tmp/ansible_terraform_payload_wd5iv42a/ansible_terraform_payload.zip/ansible_collections/community/general/plugins/modules/terraform.py\", line 711, in main\n  File \"/usr/lib64/python3.12/json/__init__.py\", line 346, in loads\n    return _default_decoder.decode(s)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib64/python3.12/json/decoder.py\", line 340, in decode\n    raise JSONDecodeError(\"Extra data\", s, end)\njson.decoder.JSONDecodeError: Extra data: line 61 column 1 (char 3006)\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

This PR:
1. Bumps the version of OpenTofu to 1.8.3
2. Adds a warning to use `use_path_style` instead of `force_path_style` in config
3. Translates existing use of `force_path_style` to `use_path_style` to preserve backwards-compatibility with existing configs
4. Adds an option to disable all of the checks and cleverness, which I envisage being useful if we're not using tofu/tf installed by the `install` role for whatever reason