### PR TITLE
Handle DNS lookup failures

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,3 +11,4 @@ repository: "https://github.com/azimuth-cloud/ansible-collection-terraform"
 
 dependencies:
   community.general: ">=7.0.0,<8.0.0"
+  ansible.utils: "5.1.2"

--- a/roles/infra/tasks/inventory_adopt.yml
+++ b/roles/infra/tasks/inventory_adopt.yml
@@ -85,6 +85,16 @@
     search_regex: OpenSSH
     timeout: 600
 
+- name: Test that cluster gateway FQDN is resolvable
+  assert:
+    that: "{{ cluster_gateway_ip is ansible.utils.resolvable }}"
+    fail_msg: "{{ cluster_gateway_ip }} cannot be resolved"
+  register: resolve
+  until: not resolve.failed
+  retries: 20
+  when: cluster_gateway_ip is not ansible.utils.ip_address
+  delegate_to: gateway
+
 - name: Wait for Ansible to connect to the gateway node
   wait_for_connection:
     # Wait for 10 mins for host to become available

--- a/roles/infra/tasks/inventory_adopt.yml
+++ b/roles/infra/tasks/inventory_adopt.yml
@@ -29,7 +29,7 @@
     # The hosts are accessed via a bastion
     # We can't just use ProxyJump here because we need agent forwarding, which is disabled even when
     # StrictHostKeyChecking=no in the case where a host key changes and the host is still in the
-    # UserKnownHostsFile
+    # UserKnownHostsFile
     # So we need to also make sure that the UserKnownHostsFile is empty for the proxy command
     cluster_ssh_common_args: >-
       -o ProxyCommand='ssh -i {{ cluster_ssh_private_key_file }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -W %h:%p {{ cluster_gateway_user }}@{{ cluster_gateway_ip }}'
@@ -45,7 +45,7 @@
 - name: Add cluster nodes to in-memory inventory
   add_host:
     name: "{{ node.name }}"
-    # Add the node to it's specified primary group and the cluster group
+    # Add the node to it's specified primary group and the cluster group
     groups: "{{ ['cluster'] + node.groups }}"
     ansible_host: "{{ node.ip }}"
     ansible_user: "{{ cluster_ssh_user }}"
@@ -80,6 +80,10 @@
   wait_for_connection:
     # Wait for 10 mins for host to become available
     timeout: 600
+    # Wait 10 seconds before attempting first connection
+    # to try to mitigate wait_for_connection module's
+    # poor handling of DNS lookup failures
+    delay: 10
   delegate_to: gateway
 
 - name: Wait for sshd to be listening on cluster nodes

--- a/roles/infra/tasks/inventory_adopt.yml
+++ b/roles/infra/tasks/inventory_adopt.yml
@@ -65,6 +65,15 @@
     loop_var: node
     label: "{{ node.name }}"
 
+- name: Test that cluster gateway FQDN is resolvable
+  assert:
+    that: "{{ cluster_gateway_ip is ansible.utils.resolvable }}"
+    fail_msg: "{{ cluster_gateway_ip }} cannot be resolved"
+  register: resolve
+  until: not resolve.failed
+  retries: 20
+  when: cluster_gateway_ip is not ansible.utils.ip_address
+
 # Using delegate_to and wait_for_connection can result in interpreter
 # discovery failures. Wait for a service to be listening on port 22
 # before wait_for_connection.
@@ -80,10 +89,6 @@
   wait_for_connection:
     # Wait for 10 mins for host to become available
     timeout: 600
-    # Wait 10 seconds before attempting first connection
-    # to try to mitigate wait_for_connection module's
-    # poor handling of DNS lookup failures
-    delay: 10
   delegate_to: gateway
 
 - name: Wait for sshd to be listening on cluster nodes

--- a/roles/infra/tasks/inventory_adopt.yml
+++ b/roles/infra/tasks/inventory_adopt.yml
@@ -65,15 +65,6 @@
     loop_var: node
     label: "{{ node.name }}"
 
-- name: Test that cluster gateway FQDN is resolvable
-  assert:
-    that: "{{ cluster_gateway_ip is ansible.utils.resolvable }}"
-    fail_msg: "{{ cluster_gateway_ip }} cannot be resolved"
-  register: resolve
-  until: not resolve.failed
-  retries: 20
-  when: cluster_gateway_ip is not ansible.utils.ip_address
-
 # Using delegate_to and wait_for_connection can result in interpreter
 # discovery failures. Wait for a service to be listening on port 22
 # before wait_for_connection.
@@ -84,16 +75,6 @@
     host: "{{ cluster_gateway_ip }}"
     search_regex: OpenSSH
     timeout: 600
-
-- name: Test that cluster gateway FQDN is resolvable
-  assert:
-    that: "{{ cluster_gateway_ip is ansible.utils.resolvable }}"
-    fail_msg: "{{ cluster_gateway_ip }} cannot be resolved"
-  register: resolve
-  until: not resolve.failed
-  retries: 20
-  when: cluster_gateway_ip is not ansible.utils.ip_address
-  delegate_to: gateway
 
 - name: Wait for Ansible to connect to the gateway node
   wait_for_connection:


### PR DESCRIPTION
It seems that the Ansible `wait_for_connection` module doesn't handle DNS lookup failures very gracefully. In Azimuth we see occasional race conditions when provisioning CaaS platforms where the Ansible logs show messages such as:

```
run {"uuid": "b25afdd4-3bf7-4a41-b98c-7f8fa79784b7", "counter": 137, "stdout":
"[WARNING]: Unhandled error in Python interpreter discovery for host
localhost:\r\nFailed to connect to the host via ssh: ssh: Could not resolve
hostname\r\nyip7s7jz6r8j2uaxewari1twmfiygcr9ttp9.zenith-services.svc.cluster.local:
Name or\r\nservice not known", "start*line": 131, "end_line": 135,
"runner_ident": "8470ded0-014 1-4940-ae3a-4d2594285205", "event": "verbose",
"pid": 31, "created": "2025-02-23T23:06:35.836954", "parent_uuid":
"1ee38f72-359e-009d-764a-0000000001ac", "event_data": {"playbook":
"workstation.yml", "playbook_uuid": "107b67c1-3734-4f7c-a823-6dc287a9f56b",
"play": "Provision infrastructure", "play_uuid":
"1ee38f72-359e-009d-764a-000000000002", "play_pattern": "openstack", "task":
"Wait for Ansible to connect to the gateway node", "task_uuid":
"1ee38f72-359e-009d-764a-0000000001ac", "task_action": "wait_for_connection",
"resolved_action": "ansible.builtin.wait_for_connection", "task_args": "",
"task* path":
"/runner/project/collections/ansible_collections/azimuth_cloud/terraform/roles/infra/tasks/inventory_adopt.yml:79",
"resolved_role": "azimuth_cloud.terraform.infra", "role": "infra", "uuid": 
"b25afdd4-3bf7-4a41-b98c-7f8fa79784b7"}}
```

which suggests that the wait for connection module is being invoked before the Zenith sync process has created the internal k8s cluster service object, resulting in a DNS resolution failure. For some reason the `wait_for_connection` module doesn't seem to retry failed DNS lookups in between connection attempts and instead just does the lookup once at the start and then fails all connection attempts and eventually times out once the configured `timeout` is reached (10 minutes in this case).

Ideally we'd solve the DNS lookup issue outwith this Ansible collection somehow since the collection is not exclusively used with k8s; however, adding a small 10 second delay here is a very low impact fix which is far simpler than anything other solution I've been able to come up with 🤷‍♂️ 

Before applying this fix I was seeing workstation creation failures around 50% of the time in my test environment (not clear why it's higher here than we see in production Azimuth installations, but it's a single master, 2 worker HA deploy so that might be related). After applying this fix, 10 / 10 workstations created successfully in my test env.